### PR TITLE
Improve Playwright test hygiene and resolve lint/prettier issues

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,6 +42,3 @@ export default defineConfig({
     },
   ],
 })
-
-
-

--- a/tests/abort-css.spec.ts
+++ b/tests/abort-css.spec.ts
@@ -9,10 +9,11 @@ test.describe('CSS Blocking Test', () => {
     await page.goto('/')
 
     // Verify that the page loads without CSS
-    const nav = await page.$('nav')
-    const backgroundColor = await nav.evaluate(
-      (el) => getComputedStyle(el).backgroundColor,
-    )
+    const nav = page.locator('nav').first()
+    await expect(nav).toBeVisible()
+    const backgroundColor = await nav.evaluate((el) => {
+      return getComputedStyle(el).backgroundColor
+    })
 
     // Check if the background color is not the default one - transparent
     expect(backgroundColor).toBe('rgba(0, 0, 0, 0)')

--- a/tests/api/favorite.api.spec.ts
+++ b/tests/api/favorite.api.spec.ts
@@ -58,6 +58,3 @@ test.describe('Favorite module tests - API', () => {
     expect(listOfFavorites).toContain(responseBody.product_id) // sprawdzamy z tego potweirdzenia czy nasze id ktore dostarczylismy, jest na tej liscie.
   })
 })
-
-
-

--- a/tests/favorite.spec.ts
+++ b/tests/favorite.spec.ts
@@ -42,6 +42,3 @@ test.describe('Testing favorite module', () => {
     await expect(favoritePage.messageFavoriteItemAdded).toBeVisible()
   })
 })
-
-
-

--- a/tests/simple.spec.ts
+++ b/tests/simple.spec.ts
@@ -3,13 +3,13 @@ import { expect, test } from '@playwright/test'
 test('Simple test of choosing category using TestCraft AI tool', async ({
   page,
 }) => {
-  await page.goto('practicesoftwareresting.com')
+  await page.goto('/')
 
-  const categoryButton = await page.locator('[data-test="nav-categories"]')
+  const categoryButton = page.locator('[data-test="nav-categories"]')
   await expect(categoryButton).toBeVisible()
 
   await categoryButton.click()
-  const powerToolsLink = await page.locator('a', { hasText: 'Power Tools' })
+  const powerToolsLink = page.locator('a', { hasText: 'Power Tools' })
   await expect(powerToolsLink).toBeVisible()
   await powerToolsLink.click()
   await expect(page).toHaveURL(


### PR DESCRIPTION
### Motivation

- Reduce flaky tests and unblock lint/prettier errors by applying small hygiene fixes to Playwright tests and config files.
- Replace fragile patterns (ElementHandle usage, incorrect base navigation and unnecessary awaits) with robust Playwright primitives and baseURL usage.

### Description

- Updated `tests/simple.spec.ts` to use the configured `baseURL` via `page.goto('/')` and removed unnecessary `await` around `locator()` calls.
- Replaced `ElementHandle` usage in `tests/abort-css.spec.ts` with a `Locator`, added an explicit `expect(nav).toBeVisible()` before calling `evaluate`, and simplified the `evaluate` callback.
- Removed trailing blank lines in `playwright.config.ts`, `tests/api/favorite.api.spec.ts`, and `tests/favorite.spec.ts` to satisfy Prettier/lint rules.

### Testing

- Ran `npm run lint` and errors from Prettier/ESLint that previously blocked CI were resolved (lint succeeded).
- Ran `npx playwright test tests/simple.spec.ts` and the test run failed in this environment because Playwright browser binaries are not installed; reproduce locally or in CI by running `npx playwright install` and re-running the tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c26c652b88323a3977fe32cf76345)